### PR TITLE
fix: resolve monthly quality check issues

### DIFF
--- a/scripts/quality-check.mjs
+++ b/scripts/quality-check.mjs
@@ -9,6 +9,12 @@ import https from 'https';
 
 const README = 'README.md';
 const OUTDATED_MONTHS = 24;
+const ARCHIVED_SECTION = '## Archived / Legacy';
+
+function activeReadmeContent(content) {
+  const idx = content.indexOf(ARCHIVED_SECTION);
+  return idx >= 0 ? content.slice(0, idx) : content;
+}
 
 function extractGitHubRepos(content) {
   const regex = /https:\/\/github\.com\/([^\/]+)\/([^\/\)\s?#]+)/g;
@@ -66,10 +72,11 @@ function fetchRepo(owner, repo, token) {
 
 async function main() {
   const content = fs.readFileSync(README, 'utf8');
-  const repos = extractGitHubRepos(content);
+  const activeContent = activeReadmeContent(content);
+  const repos = extractGitHubRepos(activeContent);
   const token = process.env.GITHUB_TOKEN;
 
-  console.log(`Checking ${repos.length} repositories...\n`);
+  console.log(`Checking ${repos.length} active repositories (excluding Archived / Legacy)...\n`);
 
   const results = [];
   for (const { owner, repo } of repos) {


### PR DESCRIPTION
## Summary
- Move 17 outdated resources into **Archived / Legacy** with year labels and modern alternatives where applicable
- Fix broken `CesiumGS/cesium-vscode` link (repo removed; points to in-development PR)
- Repair CI link-checker workflow branch trigger
- Sync `readme-zh.md` with English README changes
- Add new active resources (`3d-tiles-tools`, `cesium-vectortile-gl`, `cesium-wind-layer`, etc.)
- Update `quality-check.mjs` to skip Archived / Legacy section so monthly automation stops reopening maintenance issues

## Test plan
- [x] `GITHUB_TOKEN=$(gh auth token) node scripts/quality-check.mjs` → 0 outdated, 0 not found
- [x] README and readme-zh.md structure aligned
- [ ] CI link-checker passes on merge

Closes #2, #4, #5, #6

Made with [Cursor](https://cursor.com)